### PR TITLE
deleted authorization for index

### DIFF
--- a/app/policies/venue_policy.rb
+++ b/app/policies/venue_policy.rb
@@ -6,10 +6,6 @@ class VenuePolicy < ApplicationPolicy
     end
   end
 
-  def index?
-   true
-  end
-
   def show?
     true
   end


### PR DESCRIPTION
Deleted authorization true for index. It is not need because it has a policy scope instead.